### PR TITLE
refactor: improve query construction in Stt client

### DIFF
--- a/src/clients/stt/Client.ts
+++ b/src/clients/stt/Client.ts
@@ -82,16 +82,25 @@ export class Stt extends AbstractClient {
   ): QueryAndHeaders {
     const executionId = requestOptions.executionId || nanoid();
 
-    const query = {
+    const query: Record<string, string> = {
       execution_id: executionId,
       flow_id: requestOptions.workflowId || DEFAULT_WORKFLOW_ID,
-      lang_code: requestOptions.langCode || "en",
       time_zone: requestOptions.timeZone || "UTC",
-      tasks_config: JSON.stringify(requestOptions.tasksConfig || {}),
-      keywords: JSON.stringify(requestOptions.keywords || {}),
       "x-aiola-api-token": accessToken,
     };
 
+    if (requestOptions.langCode) {
+      query.lang_code = requestOptions.langCode;
+    }
+
+    if (requestOptions.tasksConfig) {
+      query.tasks_config = JSON.stringify(requestOptions.tasksConfig);
+    }
+
+    if (requestOptions.keywords) {
+      query.keywords = JSON.stringify(requestOptions.keywords);
+    }
+    
     const headers = {
       Authorization: `Bearer ${accessToken}`,
     };

--- a/src/lib/types/StreamingEvents.ts
+++ b/src/lib/types/StreamingEvents.ts
@@ -6,66 +6,10 @@ export interface TranslationEvent {
   translation: string;
 }
 
-export interface Entity {
-  text: string;
-  type: string;
-  description?: string;
-}
-
-export interface EntityDetectionEvent {
-  entities: Entity[];
-}
-
-export interface EntityDetectionFromListEvent {
-  entities: Entity[];
-}
-
-export interface KeyPhrasesEvent {
-  key_phrases: string[];
-}
-
-export interface FormFillingEvent {
+export interface StructuredEvent {
   results: Record<string, unknown>;
 }
 
-export interface PiiRedactionEvent {
-  redacted_text: string;
-}
-
-export interface Sentiment {
-  overall: string;
-  explanation: string;
-}
-
-export interface SentimentAnalysisEvent {
-  sentiment: Sentiment;
-}
-
-export interface SummarizationEvent {
-  summary: string;
-}
-
-export interface TopicDetectionEvent {
-  topics: string[];
-}
-
-interface ContentModeration {
-  issues: string[];
-  details: string[];
-}
-
-export interface ContentModerationEvent {
-  moderation: ContentModeration;
-}
-
-interface Chapter {
-  title: string;
-  summary: string;
-}
-
-export interface AutoChaptersEvent {
-  chapters: Chapter[];
-}
 
 export interface ServerToClientEvents {
   connect: () => void;
@@ -73,17 +17,8 @@ export interface ServerToClientEvents {
   error: (error: Error) => void;
   connect_error: (error: Error) => void;
   transcript: (data: TranscriptEvent) => void;
-  form_filling: (data: FormFillingEvent) => void;
+  structured: (data: StructuredEvent) => void;
   translation: (data: TranslationEvent) => void;
-  entity_detection: (data: EntityDetectionEvent) => void;
-  entity_detection_from_list: (data: EntityDetectionFromListEvent) => void;
-  key_phrases: (data: KeyPhrasesEvent) => void;
-  pii_redaction: (data: PiiRedactionEvent) => void;
-  sentiment_analysis: (data: SentimentAnalysisEvent) => void;
-  summarization: (data: SummarizationEvent) => void;
-  topic_detection: (data: TopicDetectionEvent) => void;
-  content_moderation: (data: ContentModerationEvent) => void;
-  auto_chapters: (data: AutoChaptersEvent) => void;
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
- Enhanced the query object in the Stt client to conditionally include `lang_code`, `tasks_config`, and `keywords` based on the presence of corresponding request options.
- Consolidated multiple event interfaces into a single `StructuredEvent` interface in StreamingEvents.ts, simplifying the event handling structure.