### PR TITLE
fix: VA-165 Add Support for min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,20 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "browser": "./dist/browser/index.mjs",
+      "browser": {
+        "require": "./dist/browser/index.js",
+        "import": "./dist/browser/index.mjs"
+      },
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
+    },
+    "./min": {
+      "browser": {
+        "require": "./dist/browser/index.min.js",
+        "import": "./dist/browser/index.min.mjs"
+      },
+      "require": "./dist/index.min.js",
+      "import": "./dist/index.min.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,17 +17,55 @@ export default defineConfig([
       }
     }
   },
-  // Browser build (ESM only)
+  // Node.js build MINIFIED (CJS + ESM)
   {
     entry: ['src/index.ts'],
-    format: ['esm'],
+    format: ['cjs', 'esm'],
+    platform: 'node',
+    dts: false,
+    splitting: false,
+    sourcemap: true,
+    minify: true,
+    outDir: 'dist',
+    outExtension({ format }) {
+      return {
+        js: format === 'cjs' ? '.min.js' : '.min.mjs'
+      }
+    }
+  },
+  // Browser build (CJS + ESM)
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
     platform: 'browser',
     dts: false,
     splitting: false,
     sourcemap: true,
     outDir: 'dist/browser',
-    outExtension() {
-      return { js: '.mjs' }
+    outExtension({ format }) {
+      return {
+        js: format === 'cjs' ? '.js' : '.mjs'
+      }
+    },
+    external: ['form-data'],
+    define: {
+      'process.env.NODE_ENV': '"production"'
+    }
+  },
+  // Browser build MINIFIED (CJS + ESM)
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    platform: 'browser',
+    dts: false,
+    splitting: false,
+    sourcemap: true,
+    minify: true,
+    outDir: 'dist/browser',
+    outExtension({ format }) {
+      return {
+        js: format === 'cjs' ? '.min.js' : '.min.mjs'
+      }
     },
     external: ['form-data'],
     define: {


### PR DESCRIPTION
Update package.json and tsup.config.ts for enhanced build configurations

- Modified package.json to support both CommonJS and ESM formats for browser builds, including minified versions.
- Updated tsup.config.ts to define separate build configurations for Node.js and browser environments, with minification options for both. This improves compatibility and optimizes output files.